### PR TITLE
Docker integration

### DIFF
--- a/CONFIG.txt
+++ b/CONFIG.txt
@@ -10,6 +10,9 @@ temp_dir:
 ploidetect_local_clone: /gsc/pipelines/Ploidetect/v1.0.0
 # ploidetect_github_version should be a branch or tag.
 ploidetect_github_version: master
+# are we using docker?
+use-docker: 1
+
 
 genome_name:
     "hg19"

--- a/Snakefile
+++ b/Snakefile
@@ -36,6 +36,7 @@ rule install_ploidetect:
     """Install Ploidetect R script into environment"""
     output:
         expand("{install_dir}/conda_configs/ploidetect_installed.txt", install_dir=workflow.basedir)
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/r.yaml"
     params:
@@ -52,6 +53,7 @@ rule germline_cov:
         bam=config["bams"]["normal"],
     output:
         temp("{temp_dir}/normal/{chr}.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -68,6 +70,7 @@ rule merge_germline:
         expand("{temp_dir}/normal/{chr}.bed", chr=chromosomes, temp_dir=temp_dir)
     output:
         temp("{temp_dir}/germline.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -81,6 +84,7 @@ rule makewindowfile:
         rules.merge_germline.output
     output:
         temp("{temp_dir}/windows.txt")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -94,6 +98,7 @@ rule splitwindowfile:
         rules.makewindowfile.output
     output:
         temp("{temp_dir}/windows/{chr}.txt")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -109,6 +114,7 @@ rule genomecovsomatic:
         window=rules.splitwindowfile.output
     output:
         temp("{temp_dir}/tumour/{chr}.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -122,6 +128,7 @@ rule mergesomatic:
         expand("{temp_dir}/tumour/{chr}.bed", chr=chromosomes, temp_dir=temp_dir)
     output:
         temp("{temp_dir}/tumour.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -139,7 +146,8 @@ rule compute_loh:
         temp("{temp_dir}/loh_tmp/loh_raw.txt")
     params:
         genome = config["genome"][config["genome_name"]],
-	array_positions = {array_positions}
+	    array_positions = {array_positions}
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -155,6 +163,7 @@ rule process_loh:
         window=rules.makewindowfile.output
     output:
         temp("{temp_dir}/loh.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -173,6 +182,7 @@ rule getgc:
         temp("{temp_dir}/gc.bed")
     params:
         genome=config["genome"][config["genome_name"]]
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -189,6 +199,7 @@ rule mergedbed:
 	    loh=rules.process_loh.output
     output:
         temp("{temp_dir}/merged.bed")
+    resources: cpus=1, mem_mb=7900
     conda:
         "conda_configs/sequence_processing.yaml"
     container:
@@ -202,6 +213,7 @@ rule preseg:
         expand("{temp_dir}/merged.bed", temp_dir=temp_dir)
     output:
         "{output_dir}/segmented.RDS"
+    resources: cpus=24, mem_mb=189600
     conda:
         "conda_configs/r.yaml"
     container:

--- a/Snakefile
+++ b/Snakefile
@@ -13,8 +13,11 @@ rule all:
     input:
         expand("{output_dir}/cna.txt", output_dir=output_dir)
 
-## Function that checks if the docker: booleaon in config is true, and if so, don't require pdt_installed.txt
 def check_docker():
+    """Ploidetect installed filepath.
+    Filename to create on a successful install or check for successful installation. 
+    Checks the config file for docker options.
+    """
     if config["use-docker"] == 1:
     # /dev/null should be present in basically every 'nix system
     # This ensures that install_ploidetect isn't run


### PR DESCRIPTION
Added a container to each relevant rule & added resources: keywords to rules. Can now submit to a slurm queue and run with singularity using an appropriate snakemake invocation e.g. 

```
snakemake --use-singularity --singularity-args "-B /path/to/bams,data/,output/" --cluster 'sbatch -t 2-00:00:00 --mem={resources.mem_mb} -c {resources.cpus} -o logs_slurm/{rule}_{wildcards} -e logs_slurm/{rule}_{wildcards} -p QUEUE'
```

as long as the use-docker: line is set to 1 in the config, otherwise it will use the conda as long as --use-conda is set.